### PR TITLE
Make the login form accept the correct auto-fill property

### DIFF
--- a/frontend/src/page/Login.jsx
+++ b/frontend/src/page/Login.jsx
@@ -106,7 +106,7 @@ const SignIn = (props) => {
   if (loading) {
     return <AppLoad />;
   }
-  
+
   return (
     <main className={classes.main}>
       <CssBaseline />
@@ -118,7 +118,7 @@ const SignIn = (props) => {
         <form className={classes.form}>
           <FormControl margin="normal" required fullWidth>
             <InputLabel htmlFor="email">zid</InputLabel>
-            <Input id="email" name="email" autoComplete="email" autoFocus placeholder="z1234567" value={zid} onChange={e => setZid(e.target.value)} />
+            <Input id="username" name="username" autoComplete="username" autoFocus placeholder="z1234567" value={zid} onChange={e => setZid(e.target.value)} />
           </FormControl>
           <FormControl margin="normal" required fullWidth>
             <InputLabel htmlFor="password">zpass</InputLabel>


### PR DESCRIPTION
Currently, the `zid` field of the login form is set up as an "email" field, which causes my password manager to fill my email rather than my zID. This pull request updates this field to use a "username" field, which should work more consistently and reliably with password managers.

I've manually tested this with the backend on the sample term, and it appeared to work correctly.