### PR TITLE
bugfix: fix zid string for sample user login

### DIFF
--- a/backend/src/student_data.js
+++ b/backend/src/student_data.js
@@ -14,7 +14,7 @@ const getStudentIds = (term) => {
           resolve([]);
           return;
       } else {
-        const zids = stdout.trim().split('\n');
+        const zids = stdout.trim().slice(1).split('\n');
         resolve([...zids, ...config.TERMS[term].TUTOR_ID_LIST, ...config.TERMS[term].AUDIT_ID_LIST]);
         return;
       }


### PR DESCRIPTION
Removed single quotation mark in front of 5555555 before resolving.
Currently, getStudentIds resolves a list containing [ '"5555555' ] causing validTermCheck in server.js to reject because '5555555' can not be found in     [ '"5555555' ].